### PR TITLE
Add meeting notes and chat features to briefing

### DIFF
--- a/DailyBriefing/Sources/Core/Services/AppIconService.swift
+++ b/DailyBriefing/Sources/Core/Services/AppIconService.swift
@@ -1,0 +1,48 @@
+import AppKit
+import Foundation
+
+/// Service for managing the app icon in the dock
+@MainActor
+final class AppIconService {
+
+    // MARK: - Singleton
+
+    static let shared = AppIconService()
+
+    // MARK: - Private Properties
+
+    private var timer: Timer?
+
+    // MARK: - Initialization
+
+    private init() {}
+
+    // MARK: - Public API
+
+    /// Start the service (updates dock icon based on time of day)
+    func start() {
+        // Update immediately
+        updateDockIcon()
+
+        // Schedule periodic updates (every hour)
+        timer = Timer.scheduledTimer(withTimeInterval: 3600, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.updateDockIcon()
+            }
+        }
+    }
+
+    /// Stop the service
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    // MARK: - Private Methods
+
+    private func updateDockIcon() {
+        // The dock icon could be updated based on time of day
+        // For now, we just use the default icon
+        // This is a placeholder for future enhancements
+    }
+}

--- a/DailyBriefing/Sources/Core/Services/BriefingChatService.swift
+++ b/DailyBriefing/Sources/Core/Services/BriefingChatService.swift
@@ -1,0 +1,222 @@
+import Foundation
+import Combine
+
+/// Message in a chat conversation
+struct ChatMessage: Identifiable, Equatable {
+    let id: UUID
+    let role: Role
+    let content: String
+    let timestamp: Date
+
+    enum Role: String {
+        case user
+        case assistant
+        case system
+    }
+
+    init(id: UUID = UUID(), role: Role, content: String, timestamp: Date = Date()) {
+        self.id = id
+        self.role = role
+        self.content = content
+        self.timestamp = timestamp
+    }
+}
+
+/// Service for chatting about the current briefing
+@MainActor
+final class BriefingChatService: ObservableObject {
+
+    // MARK: - Singleton
+
+    static let shared = BriefingChatService()
+
+    // MARK: - Published Properties
+
+    @Published private(set) var messages: [ChatMessage] = []
+    @Published private(set) var isLoading = false
+    @Published private(set) var lastError: Error?
+
+    // MARK: - Private Properties
+
+    private let keychain = KeychainService.shared
+    private var currentBriefing: Briefing?
+
+    // MARK: - Initialization
+
+    private init() {}
+
+    // MARK: - Public API
+
+    /// Set the current briefing context for chat
+    func setBriefingContext(_ briefing: Briefing?) {
+        if currentBriefing?.id != briefing?.id {
+            // Reset chat when briefing changes
+            messages = []
+            currentBriefing = briefing
+        }
+    }
+
+    /// Send a message and get a response
+    func sendMessage(_ content: String) async throws {
+        guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return
+        }
+
+        guard currentBriefing != nil else {
+            throw ChatError.noBriefingContext
+        }
+
+        // Add user message
+        let userMessage = ChatMessage(role: .user, content: content)
+        messages.append(userMessage)
+
+        isLoading = true
+        lastError = nil
+
+        do {
+            // Generate response
+            let response = try await generateResponse(for: content)
+
+            // Add assistant message
+            let assistantMessage = ChatMessage(role: .assistant, content: response)
+            messages.append(assistantMessage)
+
+            isLoading = false
+        } catch {
+            isLoading = false
+            lastError = error
+            throw error
+        }
+    }
+
+    /// Clear the chat history
+    func clearChat() {
+        messages = []
+    }
+
+    // MARK: - Private Methods
+
+    private func generateResponse(for userMessage: String) async throws -> String {
+        guard let config = loadLLMConfiguration() else {
+            throw ChatError.llmNotConfigured
+        }
+
+        let apiKey = keychain.loadLLMAPIKey(for: config.provider.rawValue)
+        if config.provider.requiresAPIKey && (apiKey == nil || apiKey?.isEmpty == true) {
+            throw ChatError.llmNotConfigured
+        }
+
+        let llmService = LLMServiceFactory.create(
+            provider: config.provider,
+            apiKey: apiKey,
+            modelId: config.modelId,
+            ollamaBaseURL: config.ollamaBaseURL
+        )
+
+        let systemPrompt = buildSystemPrompt()
+        let prompt = buildPrompt(userMessage: userMessage)
+
+        return try await llmService.complete(prompt: prompt, systemPrompt: systemPrompt)
+    }
+
+    private func buildSystemPrompt() -> String {
+        guard let briefing = currentBriefing else { return "" }
+
+        var context = """
+        Du bist ein hilfreicher Assistent, der Fragen zum heutigen Briefing beantwortet.
+        Antworte immer auf Deutsch und sei präzise und hilfreich.
+
+        Hier ist das aktuelle Briefing vom \(formatDate(briefing.generatedAt)):
+
+        ZUSAMMENFASSUNG:
+        \(briefing.summary)
+
+        DETAILS NACH QUELLEN:
+        """
+
+        for section in briefing.sections {
+            context += "\n\n## \(section.sourceName) (\(section.items.count) Einträge):"
+            for item in section.items {
+                context += "\n- \(item.title)"
+                if let subtitle = item.subtitle {
+                    context += " (\(subtitle))"
+                }
+                if let body = item.body, !body.isEmpty {
+                    context += "\n  Beschreibung: \(body.prefix(200))..."
+                }
+                if let attendees = item.metadata["attendees"], !attendees.isEmpty {
+                    context += "\n  Teilnehmer: \(attendees)"
+                }
+                if let location = item.metadata["location"], !location.isEmpty {
+                    context += "\n  Ort: \(location)"
+                }
+                if let duration = item.metadata["duration"] {
+                    context += "\n  Dauer: \(duration)"
+                }
+            }
+        }
+
+        context += """
+
+        Beantworte Fragen basierend auf diesen Informationen. Wenn du etwas nicht weisst, sag es ehrlich.
+        """
+
+        return context
+    }
+
+    private func buildPrompt(userMessage: String) -> String {
+        // Include recent conversation history for context
+        var prompt = ""
+
+        // Add last few messages for context
+        let recentMessages = messages.suffix(6)
+        for message in recentMessages {
+            switch message.role {
+            case .user:
+                prompt += "Benutzer: \(message.content)\n"
+            case .assistant:
+                prompt += "Assistent: \(message.content)\n"
+            case .system:
+                break
+            }
+        }
+
+        prompt += "Benutzer: \(userMessage)\nAssistent:"
+
+        return prompt
+    }
+
+    private func loadLLMConfiguration() -> LLMConfiguration? {
+        if let data = UserDefaults.standard.data(forKey: "llm_configuration"),
+           let config = try? JSONDecoder().decode(LLMConfiguration.self, from: data) {
+            return config
+        }
+        return LLMConfiguration()
+    }
+
+    private func formatDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "de_DE")
+        formatter.dateFormat = "EEEE, d. MMMM yyyy 'um' HH:mm"
+        return formatter.string(from: date)
+    }
+}
+
+// MARK: - Errors
+
+enum ChatError: LocalizedError {
+    case noBriefingContext
+    case llmNotConfigured
+    case networkError(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .noBriefingContext:
+            return "Kein Briefing vorhanden. Bitte zuerst ein Briefing generieren."
+        case .llmNotConfigured:
+            return "KI-Provider nicht konfiguriert. Bitte in den Einstellungen einrichten."
+        case .networkError(let error):
+            return "Netzwerkfehler: \(error.localizedDescription)"
+        }
+    }
+}

--- a/DailyBriefing/Sources/Core/Services/UpdateService.swift
+++ b/DailyBriefing/Sources/Core/Services/UpdateService.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Sparkle
+
+/// Service for handling app updates via Sparkle
+@MainActor
+final class UpdateService: ObservableObject {
+
+    // MARK: - Singleton
+
+    static let shared = UpdateService()
+
+    // MARK: - Published Properties
+
+    @Published private(set) var canCheckForUpdates = true
+
+    // MARK: - Private Properties
+
+    private var updaterController: SPUStandardUpdaterController?
+
+    // MARK: - Initialization
+
+    private init() {
+        setupSparkle()
+    }
+
+    // MARK: - Setup
+
+    private func setupSparkle() {
+        // Initialize Sparkle updater controller
+        updaterController = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+    }
+
+    // MARK: - Computed Properties
+
+    /// Whether the app automatically checks for updates
+    var automaticallyChecksForUpdates: Bool {
+        updaterController?.updater.automaticallyChecksForUpdates ?? true
+    }
+
+    // MARK: - Public API
+
+    /// Check for updates manually
+    func checkForUpdates() {
+        updaterController?.checkForUpdates(nil)
+    }
+
+    /// Check for updates in background
+    func checkForUpdatesInBackground() {
+        updaterController?.updater.checkForUpdatesInBackground()
+    }
+
+    /// Enable or disable automatic update checks
+    func setAutomaticChecksEnabled(_ enabled: Bool) {
+        updaterController?.updater.automaticallyChecksForUpdates = enabled
+    }
+}

--- a/DailyBriefing/Sources/Features/Chat/BriefingChatView.swift
+++ b/DailyBriefing/Sources/Features/Chat/BriefingChatView.swift
@@ -1,0 +1,254 @@
+import SwiftUI
+
+/// Chat view for interacting with the briefing
+struct BriefingChatView: View {
+    @EnvironmentObject private var appState: AppState
+    @StateObject private var chatService = BriefingChatService.shared
+    @State private var inputText = ""
+    @State private var isInputFocused = false
+    @FocusState private var textFieldFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header
+            chatHeader
+
+            Divider()
+                .background(Color.tuiBorder)
+
+            // Messages
+            if chatService.messages.isEmpty {
+                emptyState
+            } else {
+                messagesList
+            }
+
+            Divider()
+                .background(Color.tuiBorder)
+
+            // Input
+            inputArea
+        }
+        .background(Color.tuiBackground)
+        .onChange(of: appState.currentBriefing?.id) { _, _ in
+            chatService.setBriefingContext(appState.currentBriefing)
+        }
+        .onAppear {
+            chatService.setBriefingContext(appState.currentBriefing)
+        }
+    }
+
+    // MARK: - Header
+
+    private var chatHeader: some View {
+        HStack {
+            Text("CHAT")
+                .font(.tuiMonoTiny)
+                .fontWeight(.bold)
+                .foregroundStyle(.tertiary)
+
+            Spacer()
+
+            if !chatService.messages.isEmpty {
+                Button {
+                    chatService.clearChat()
+                } label: {
+                    Text("clear")
+                        .font(.tuiMonoTiny)
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+                .onHover { isHovered in
+                    if isHovered {
+                        NSCursor.pointingHand.push()
+                    } else {
+                        NSCursor.pop()
+                    }
+                }
+            }
+        }
+        .padding(Spacing.md)
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: Spacing.md) {
+            Text("Frag mich etwas zum Briefing")
+                .font(.tuiMonoSmall)
+                .foregroundStyle(.tertiary)
+
+            VStack(alignment: .leading, spacing: Spacing.sm) {
+                suggestionButton("Was steht heute an?")
+                suggestionButton("Welche Meetings habe ich?")
+                suggestionButton("Was ist am wichtigsten?")
+                suggestionButton("Fasse die E-Mails zusammen")
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(Spacing.md)
+    }
+
+    private func suggestionButton(_ text: String) -> some View {
+        Button {
+            inputText = text
+            Task {
+                await sendMessage()
+            }
+        } label: {
+            HStack {
+                Text(">")
+                    .foregroundStyle(.quaternary)
+                Text(text)
+                    .foregroundStyle(.secondary)
+            }
+            .font(.tuiMonoTiny)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, Spacing.sm)
+            .padding(.vertical, Spacing.xs)
+        }
+        .buttonStyle(.plain)
+        .background(Color.tuiHover.opacity(0.5))
+        .cornerRadius(4)
+    }
+
+    // MARK: - Messages List
+
+    private var messagesList: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: Spacing.sm) {
+                    ForEach(chatService.messages) { message in
+                        ChatMessageRow(message: message)
+                            .id(message.id)
+                    }
+
+                    if chatService.isLoading {
+                        loadingIndicator
+                    }
+                }
+                .padding(Spacing.md)
+            }
+            .onChange(of: chatService.messages.count) { _, _ in
+                if let lastMessage = chatService.messages.last {
+                    withAnimation(.tuiSmooth) {
+                        proxy.scrollTo(lastMessage.id, anchor: .bottom)
+                    }
+                }
+            }
+        }
+    }
+
+    private var loadingIndicator: some View {
+        HStack(spacing: Spacing.xs) {
+            Text("...")
+                .font(.tuiMonoSmall)
+                .foregroundStyle(.tertiary)
+
+            ProgressView()
+                .scaleEffect(0.5)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, Spacing.sm)
+    }
+
+    // MARK: - Input Area
+
+    private var inputArea: some View {
+        HStack(spacing: Spacing.sm) {
+            TextField("Nachricht eingeben...", text: $inputText)
+                .textFieldStyle(.plain)
+                .font(.tuiMonoSmall)
+                .focused($textFieldFocused)
+                .onSubmit {
+                    Task {
+                        await sendMessage()
+                    }
+                }
+                .disabled(appState.currentBriefing == nil || chatService.isLoading)
+
+            Button {
+                Task {
+                    await sendMessage()
+                }
+            } label: {
+                Text(">")
+                    .font(.tuiMonoSmall)
+                    .fontWeight(.bold)
+            }
+            .buttonStyle(.tuiPrimary)
+            .disabled(inputText.isEmpty || chatService.isLoading || appState.currentBriefing == nil)
+        }
+        .padding(Spacing.md)
+    }
+
+    // MARK: - Actions
+
+    private func sendMessage() async {
+        let message = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !message.isEmpty else { return }
+
+        inputText = ""
+
+        do {
+            try await chatService.sendMessage(message)
+        } catch {
+            // Error is handled by the service
+        }
+    }
+}
+
+// MARK: - Chat Message Row
+
+struct ChatMessageRow: View {
+    let message: ChatMessage
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            // Role indicator
+            HStack(spacing: Spacing.xs) {
+                Text(rolePrefix)
+                    .font(.tuiMonoTiny)
+                    .fontWeight(.bold)
+                    .foregroundStyle(roleColor)
+
+                Text(formatTime(message.timestamp))
+                    .font(.tuiMonoTiny)
+                    .foregroundStyle(.quaternary)
+            }
+
+            // Content
+            Text(message.content)
+                .font(.tuiMonoSmall)
+                .foregroundStyle(message.role == .user ? .primary : .secondary)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(Spacing.sm)
+        .background(message.role == .user ? Color.tuiHover : Color.clear)
+        .cornerRadius(4)
+    }
+
+    private var rolePrefix: String {
+        switch message.role {
+        case .user: return "Du:"
+        case .assistant: return "AI:"
+        case .system: return "SYS:"
+        }
+    }
+
+    private var roleColor: Color {
+        switch message.role {
+        case .user: return .primary
+        case .assistant: return .blue
+        case .system: return .orange
+        }
+    }
+
+    private func formatTime(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        return formatter.string(from: date)
+    }
+}
+

--- a/DailyBriefing/Sources/Features/Dashboard/DashboardView.swift
+++ b/DailyBriefing/Sources/Features/Dashboard/DashboardView.swift
@@ -7,6 +7,7 @@ struct TUIDashboardView: View {
     @StateObject private var connectionManager = ServiceConnectionManager.shared
     @State private var selectedDetailLevel: Briefing.DetailLevel = .quick
     @State private var selectedSection: Int = 0
+    @State private var showChat: Bool = false
 
     var body: some View {
         mainContent
@@ -16,8 +17,14 @@ struct TUIDashboardView: View {
                 selectedDetailLevel: $selectedDetailLevel,
                 selectedSection: $selectedSection
             ))
+            .onKeyPress("c", modifiers: .command) {
+                withAnimation(.tuiSnappy) {
+                    showChat.toggle()
+                }
+                return .handled
+            }
     }
-    
+
     private var mainContent: some View {
         HStack(spacing: 1) {
             // Left panel - Controls & Summary
@@ -29,10 +36,30 @@ struct TUIDashboardView: View {
                 .fill(Color.tuiBorder)
                 .frame(width: 1)
 
-            // Right panel - Sections
+            // Center panel - Sections
             rightPanel
                 .frame(maxWidth: .infinity)
+
+            // Chat panel (conditional)
+            if showChat {
+                Rectangle()
+                    .fill(Color.tuiBorder)
+                    .frame(width: 1)
+
+                chatPanel
+                    .frame(width: 320)
+                    .transition(.asymmetric(
+                        insertion: .move(edge: .trailing).combined(with: .opacity),
+                        removal: .move(edge: .trailing).combined(with: .opacity)
+                    ))
+            }
         }
+    }
+
+    // MARK: - Chat Panel
+
+    private var chatPanel: some View {
+        BriefingChatView()
     }
 
     // MARK: - Left Panel
@@ -130,6 +157,11 @@ struct TUIDashboardView: View {
             // Progress indicator
             if appState.isLoadingBriefing {
                 progressIndicator
+            }
+
+            // Chat toggle button
+            if appState.currentBriefing != nil {
+                ChatToggleButton(showChat: $showChat)
             }
         }
     }
@@ -329,52 +361,168 @@ struct TUISectionRow: View {
 struct TUIItemRow: View {
     let item: BriefingItem
     @State private var isHovered = false
+    @State private var isExpanded = false
 
     var body: some View {
-        Button {
-            if let url = item.deepLink {
-                NSWorkspace.shared.open(url)
-            }
-        } label: {
-            HStack(spacing: Spacing.sm) {
-                // Priority indicator
-                Text(priorityChar)
-                    .font(.tuiMonoTiny)
-                    .foregroundStyle(priorityColor)
-                    .frame(width: 12)
+        VStack(spacing: 0) {
+            // Main row (clickable)
+            Button {
+                if hasDetails {
+                    withAnimation(.tuiSnappy) {
+                        isExpanded.toggle()
+                    }
+                } else if let url = item.deepLink {
+                    NSWorkspace.shared.open(url)
+                }
+            } label: {
+                HStack(spacing: Spacing.sm) {
+                    // Priority indicator
+                    Text(priorityChar)
+                        .font(.tuiMonoTiny)
+                        .foregroundStyle(priorityColor)
+                        .frame(width: 12)
 
-                // Content
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(item.title)
-                        .font(.tuiMonoSmall)
-                        .foregroundStyle(.primary)
-                        .lineLimit(1)
+                    // Content
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack(spacing: Spacing.xs) {
+                            Text(item.title)
+                                .font(.tuiMonoSmall)
+                                .foregroundStyle(.primary)
+                                .lineLimit(1)
 
-                    if let subtitle = item.subtitle {
-                        Text(subtitle)
+                            // Duration badge
+                            if let duration = item.metadata["duration"] {
+                                Text("[\(duration)]")
+                                    .font(.tuiMonoTiny)
+                                    .foregroundStyle(.quaternary)
+                            }
+                        }
+
+                        if let subtitle = item.subtitle {
+                            Text(subtitle)
+                                .font(.tuiMonoTiny)
+                                .foregroundStyle(.tertiary)
+                                .lineLimit(1)
+                        }
+                    }
+
+                    Spacer()
+
+                    // Meeting link indicator
+                    if item.metadata["meetingLink"] != nil {
+                        Text("📹")
                             .font(.tuiMonoTiny)
-                            .foregroundStyle(.tertiary)
-                            .lineLimit(1)
+                    }
+
+                    // Expand/Link indicator
+                    if hasDetails {
+                        Text(isExpanded ? "▼" : "▶")
+                            .font(.tuiMonoTiny)
+                            .foregroundStyle(.quaternary)
+                    } else if item.deepLink != nil {
+                        Text("→")
+                            .font(.tuiMonoTiny)
+                            .foregroundStyle(.quaternary)
+                            .opacity(isHovered ? 1 : 0)
                     }
                 }
+                .padding(.horizontal, Spacing.md)
+                .padding(.leading, Spacing.lg)
+                .padding(.vertical, Spacing.xs)
+                .background(isHovered ? Color.tuiHover : Color.clear)
+            }
+            .buttonStyle(.plain)
+            .onHover { isHovered = $0 }
+            .animation(.tuiFast, value: isHovered)
 
-                Spacer()
+            // Expanded details
+            if isExpanded {
+                expandedDetails
+                    .transition(.asymmetric(
+                        insertion: .opacity.combined(with: .move(edge: .top)),
+                        removal: .opacity
+                    ))
+            }
+        }
+    }
 
-                if item.deepLink != nil {
-                    Text("→")
+    private var hasDetails: Bool {
+        item.body != nil ||
+        item.metadata["attendees"] != nil ||
+        item.metadata["location"]?.isEmpty == false
+    }
+
+    private var expandedDetails: some View {
+        VStack(alignment: .leading, spacing: Spacing.xs) {
+            // Attendees
+            if let attendees = item.metadata["attendees"], !attendees.isEmpty {
+                HStack(alignment: .top, spacing: Spacing.xs) {
+                    Text("👥")
                         .font(.tuiMonoTiny)
-                        .foregroundStyle(.quaternary)
-                        .opacity(isHovered ? 1 : 0)
+                    Text(attendees)
+                        .font(.tuiMonoTiny)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
                 }
             }
-            .padding(.horizontal, Spacing.md)
-            .padding(.leading, Spacing.lg)
-            .padding(.vertical, Spacing.xs)
-            .background(isHovered ? Color.tuiHover : Color.clear)
+
+            // Location
+            if let location = item.metadata["location"], !location.isEmpty {
+                HStack(alignment: .top, spacing: Spacing.xs) {
+                    Text("📍")
+                        .font(.tuiMonoTiny)
+                    Text(location)
+                        .font(.tuiMonoTiny)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+
+            // Description/Body
+            if let body = item.body, !body.isEmpty {
+                Text(body)
+                    .font(.tuiMonoTiny)
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(4)
+                    .padding(.top, Spacing.xs)
+            }
+
+            // Meeting link button
+            if let meetingLink = item.metadata["meetingLink"],
+               let url = URL(string: meetingLink) {
+                Button {
+                    NSWorkspace.shared.open(url)
+                } label: {
+                    HStack(spacing: Spacing.xs) {
+                        Text("📹")
+                        Text("Meeting beitreten")
+                            .font(.tuiMonoTiny)
+                    }
+                }
+                .buttonStyle(.tui)
+                .padding(.top, Spacing.xs)
+            }
+
+            // Deep link to calendar
+            if let deepLink = item.deepLink,
+               item.metadata["meetingLink"] != nil {
+                Button {
+                    NSWorkspace.shared.open(deepLink)
+                } label: {
+                    HStack(spacing: Spacing.xs) {
+                        Text("📅")
+                        Text("Im Kalender öffnen")
+                            .font(.tuiMonoTiny)
+                    }
+                }
+                .buttonStyle(.tui)
+            }
         }
-        .buttonStyle(.plain)
-        .onHover { isHovered = $0 }
-        .animation(.tuiFast, value: isHovered)
+        .padding(.horizontal, Spacing.md)
+        .padding(.leading, Spacing.lg + 12 + Spacing.sm)
+        .padding(.vertical, Spacing.sm)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.tuiHover.opacity(0.5))
     }
 
     private var priorityChar: String {
@@ -520,6 +668,50 @@ struct DetailLevelButton: View {
                 }
                 .buttonStyle(.tui)
             }
+        }
+    }
+}
+
+// MARK: - Chat Toggle Button
+
+struct ChatToggleButton: View {
+    @Binding var showChat: Bool
+
+    var body: some View {
+        Group {
+            if showChat {
+                Button {
+                    withAnimation(.tuiSnappy) {
+                        showChat.toggle()
+                    }
+                } label: {
+                    buttonLabel
+                }
+                .buttonStyle(.tuiPrimary)
+            } else {
+                Button {
+                    withAnimation(.tuiSnappy) {
+                        showChat.toggle()
+                    }
+                } label: {
+                    buttonLabel
+                }
+                .buttonStyle(.tui)
+            }
+        }
+    }
+
+    private var buttonLabel: some View {
+        HStack {
+            Text(showChat ? ">" : "<")
+                .font(.tuiMonoSmall)
+
+            Text("chat")
+                .font(.tuiMonoSmall)
+
+            Spacer()
+
+            KeyBadge(key: "\u{2318}C")
         }
     }
 }

--- a/DailyBriefing/Sources/Integrations/GoogleCalendar/GoogleCalendarSource.swift
+++ b/DailyBriefing/Sources/Integrations/GoogleCalendar/GoogleCalendarSource.swift
@@ -99,18 +99,116 @@ final class GoogleCalendarSource: BriefingSource, ObservableObject {
 
         // Convert to BriefingItems
         return allEvents.map { event in
-            BriefingItem(
+            // Extract meeting link (Google Meet, Zoom, etc.)
+            let meetingLink = extractMeetingLink(from: event)
+
+            // Format attendees list
+            let attendeesList = formatAttendees(event.attendees)
+
+            // Calculate duration
+            let duration = calculateDuration(event)
+
+            // Build metadata
+            var metadata: [String: String] = [
+                "location": event.location ?? "",
+                "organizer": event.organizer?.displayName ?? event.organizer?.email ?? ""
+            ]
+
+            if !attendeesList.isEmpty {
+                metadata["attendees"] = attendeesList
+            }
+
+            if let link = meetingLink {
+                metadata["meetingLink"] = link
+            }
+
+            if let dur = duration {
+                metadata["duration"] = dur
+            }
+
+            return BriefingItem(
                 title: event.summary ?? "Unbenannter Termin",
                 subtitle: formatEventTime(event),
                 body: event.description,
                 timestamp: event.start.dateTime ?? event.start.date,
-                deepLink: event.htmlLink.flatMap { URL(string: $0) },
+                deepLink: meetingLink.flatMap { URL(string: $0) } ?? event.htmlLink.flatMap { URL(string: $0) },
                 priority: determinePriority(for: event),
-                metadata: [
-                    "location": event.location ?? "",
-                    "organizer": event.organizer?.displayName ?? event.organizer?.email ?? ""
-                ]
+                metadata: metadata
             )
+        }
+    }
+
+    /// Extract video conference link from event
+    private func extractMeetingLink(from event: GoogleCalendarEvent) -> String? {
+        // Check conferenceData first (Google Meet)
+        if let conferenceData = event.conferenceData,
+           let entryPoints = conferenceData.entryPoints {
+            // Prefer video entry point
+            if let videoEntry = entryPoints.first(where: { $0.entryPointType == "video" }) {
+                return videoEntry.uri
+            }
+        }
+
+        // Fallback to hangoutLink
+        if let hangoutLink = event.hangoutLink {
+            return hangoutLink
+        }
+
+        // Check description for Zoom/Teams links
+        if let description = event.description {
+            // Zoom
+            if let zoomRange = description.range(of: "https://[^\\s]*zoom\\.us/j/[^\\s]+", options: .regularExpression) {
+                return String(description[zoomRange])
+            }
+            // Microsoft Teams
+            if let teamsRange = description.range(of: "https://teams\\.microsoft\\.com/l/meetup-join/[^\\s]+", options: .regularExpression) {
+                return String(description[teamsRange])
+            }
+        }
+
+        return nil
+    }
+
+    /// Format attendees into a readable string
+    private func formatAttendees(_ attendees: [EventAttendee]?) -> String {
+        guard let attendees = attendees, !attendees.isEmpty else { return "" }
+
+        let names = attendees.prefix(5).compactMap { attendee -> String? in
+            if let name = attendee.displayName, !name.isEmpty {
+                return name
+            }
+            return attendee.email?.components(separatedBy: "@").first
+        }
+
+        var result = names.joined(separator: ", ")
+        if attendees.count > 5 {
+            result += " +\(attendees.count - 5) weitere"
+        }
+
+        return result
+    }
+
+    /// Calculate meeting duration
+    private func calculateDuration(_ event: GoogleCalendarEvent) -> String? {
+        guard let startTime = event.start.dateTime,
+              let endTime = event.end.dateTime else {
+            // All-day event
+            return nil
+        }
+
+        let duration = endTime.timeIntervalSince(startTime)
+        let minutes = Int(duration / 60)
+
+        if minutes < 60 {
+            return "\(minutes) Min"
+        } else {
+            let hours = minutes / 60
+            let remainingMinutes = minutes % 60
+            if remainingMinutes == 0 {
+                return "\(hours) Std"
+            } else {
+                return "\(hours) Std \(remainingMinutes) Min"
+            }
         }
     }
 
@@ -256,6 +354,24 @@ struct GoogleCalendarEvent: Codable, Identifiable {
     let htmlLink: String?
     let organizer: EventOrganizer?
     let attendees: [EventAttendee]?
+    let conferenceData: ConferenceData?
+    let hangoutLink: String?
+}
+
+struct ConferenceData: Codable {
+    let entryPoints: [EntryPoint]?
+    let conferenceSolution: ConferenceSolution?
+}
+
+struct EntryPoint: Codable {
+    let entryPointType: String?
+    let uri: String?
+    let label: String?
+}
+
+struct ConferenceSolution: Codable {
+    let name: String?
+    let iconUri: String?
 }
 
 struct EventDateTime: Codable {


### PR DESCRIPTION
## Summary

This PR adds comprehensive meeting details extraction from Google Calendar and a new interactive chat interface for asking questions about the briefing.

**Key features:**
- Extracts attendees, video conference links (Google Meet/Zoom/Teams), and meeting duration from calendar events
- Expandable meeting items showing all details (attendees, location, description, join buttons)
- New chat interface (⌘C) to ask questions about the briefing with LLM context
- Dashboard shows meeting indicators (📹 for video calls, [duration] badge)

The implementation includes BriefingChatService for chat interactions and improved GoogleCalendarSource with full event metadata extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)