### PR TITLE
fix: re-sign app bundle after copying frameworks

### DIFF
--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -133,6 +133,11 @@ PLIST
 
 popd >/dev/null
 
+# Re-sign the app bundle with ad-hoc signature
+# This is critical after copying frameworks to ensure the app can launch
+echo "Signing app bundle..."
+codesign --force --deep --sign - "${APP_DIR}"
+
 ZIP_PATH="${DIST_DIR}/${APP_NAME}-${VERSION}.zip"
 rm -f "${ZIP_PATH}"
 ditto -c -k --sequesterRsrc --keepParent "${APP_DIR}" "${ZIP_PATH}"

--- a/scripts/run-app.sh
+++ b/scripts/run-app.sh
@@ -123,6 +123,11 @@ ${SPARKLE_PLIST_KEYS}
 </plist>
 PLIST
 
+# Re-sign the app bundle with ad-hoc signature
+# This is critical after copying frameworks to ensure the app can launch
+echo "Signing app bundle..."
+codesign --force --deep --sign - "${APP_DIR}" >/dev/null 2>&1
+
 echo "Launching: ${APP_DIR}"
 open -n "${APP_DIR}"
 


### PR DESCRIPTION
## Summary

Fixes app crash on launch caused by invalid code signature after copying Sparkle.framework into the app bundle.

- Added `codesign --force --deep --sign -` to `run-app.sh` (development builds)
- Added `codesign --force --deep --sign -` to `package-release.sh` (release builds)

The app now launches successfully.