### PR TITLE
Ensure main window opens on launch

### DIFF
--- a/DailyBriefing/Sources/App/AppDelegate.swift
+++ b/DailyBriefing/Sources/App/AppDelegate.swift
@@ -1,0 +1,17 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // Ensure the main window is visible on first launch.
+        MainWindowController.shared.show()
+    }
+
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        if !flag {
+            MainWindowController.shared.show()
+        }
+        return true
+    }
+}

--- a/DailyBriefing/Sources/App/AppState.swift
+++ b/DailyBriefing/Sources/App/AppState.swift
@@ -4,6 +4,7 @@ import Combine
 /// Central app state management
 @MainActor
 final class AppState: ObservableObject {
+    static let shared = AppState()
 
     // MARK: - Navigation
 

--- a/DailyBriefing/Sources/App/DailyBriefingApp.swift
+++ b/DailyBriefing/Sources/App/DailyBriefingApp.swift
@@ -3,7 +3,8 @@ import AppIntents
 
 @main
 struct DailyBriefingApp: App {
-    @StateObject private var appState = AppState()
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+    @StateObject private var appState = AppState.shared
     @StateObject private var settingsStore = UserSettingsStore.shared
     @StateObject private var updateService = UpdateService.shared
 
@@ -13,8 +14,12 @@ struct DailyBriefingApp: App {
     private let shortcutService = GlobalShortcutService.shared
     private let notificationService = NotificationService.shared
 
+    init() {
+        // Window is shown by AppDelegate after NSApplication finished launching.
+    }
+
     var body: some Scene {
-        WindowGroup {
+        Window("Daily Briefing", id: "main") {
             ContentView()
                 .environmentObject(appState)
                 .environmentObject(settingsStore)

--- a/DailyBriefing/Sources/App/MainWindowController.swift
+++ b/DailyBriefing/Sources/App/MainWindowController.swift
@@ -1,0 +1,40 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class MainWindowController {
+    static let shared = MainWindowController()
+
+    private var window: NSWindow?
+
+    func show() {
+        NSApplication.shared.setActivationPolicy(.regular)
+        NSApplication.shared.activate(ignoringOtherApps: true)
+
+        if let existing = NSApplication.shared.windows.first(where: { $0.canBecomeKey && $0.level == .normal }) {
+            existing.makeKeyAndOrderFront(nil)
+            existing.orderFrontRegardless()
+            return
+        }
+
+        if window == nil {
+            let contentView = ContentView()
+                .environmentObject(AppState.shared)
+                .environmentObject(UserSettingsStore.shared)
+
+            let hostingController = NSHostingController(rootView: contentView)
+            let window = NSWindow(contentViewController: hostingController)
+            window.title = "Daily Briefing"
+            window.setContentSize(NSSize(width: 700, height: 500))
+            window.minSize = NSSize(width: 500, height: 400)
+            window.titleVisibility = .hidden
+            window.titlebarAppearsTransparent = true
+            window.isReleasedWhenClosed = false
+            window.center()
+            self.window = window
+        }
+
+        window?.makeKeyAndOrderFront(nil)
+        window?.orderFrontRegardless()
+    }
+}


### PR DESCRIPTION
Create a dedicated main window controller and show it after launch/reopen. This makes the GUI appear reliably when the app starts.