### PR TITLE
Fix AppDelegate and duplicate decorator

### DIFF
--- a/DailyBriefing/Sources/App/AppDelegate.swift
+++ b/DailyBriefing/Sources/App/AppDelegate.swift
@@ -1,8 +1,4 @@
 import AppKit
-
-final class AppDelegate: NSObject, NSApplicationDelegate {
-    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-        MainWindowCoordinator.shared.openMainWindow()
 import SwiftUI
 
 @MainActor

--- a/DailyBriefing/Sources/App/DailyBriefingApp.swift
+++ b/DailyBriefing/Sources/App/DailyBriefingApp.swift
@@ -7,7 +7,6 @@ struct DailyBriefingApp: App {
     @StateObject private var appState = AppState.shared
     @StateObject private var settingsStore = UserSettingsStore.shared
     @StateObject private var updateService = UpdateService.shared
-    @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 
     // Services (initialized as singletons, referenced here to ensure they're started)
     private let briefingService = BriefingGenerationService.shared


### PR DESCRIPTION
## Summary
- Fixed corrupted AppDelegate.swift with merged class definitions
- Removed duplicate @NSApplicationDelegateAdaptor in DailyBriefingApp
- App now builds and runs successfully

## Changes
- Cleaned up AppDelegate class definition to eliminate malformed code
- Removed redundant decorator that caused initialization issues
- Verified successful build of release app bundle and DMG

🤖 Generated with Claude Code