### PR TITLE
Fix: Add condition to prevent workflow from running on regular pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ env:
 jobs:
   build-and-release:
     runs-on: macos-14
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
       pages: write


### PR DESCRIPTION
Fixes workflow failures on regular pushes by adding a condition that only allows the workflow to run on tag pushes or manual dispatch.