### PR TITLE
Fix Sparkle update feed URL migration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,10 +116,16 @@ jobs:
           )
           
           # Try to fetch existing appcast.xml from gh-pages
+          # First try new location, then fall back to old location for migration
           EXISTING_ITEMS=""
-          if git fetch origin gh-pages:gh-pages 2>/dev/null && git show gh-pages:DailyDigest/appcast.xml > dist/existing-appcast.xml 2>/dev/null; then
-            # Extract existing items (between <channel> and </channel>, excluding channel tags)
-            EXISTING_ITEMS=$(sed -n '/<channel>/,/<\/channel>/p' dist/existing-appcast.xml | sed '1d;$d' | grep -v '^[[:space:]]*</channel>' || true)
+          if git fetch origin gh-pages:gh-pages 2>/dev/null; then
+            if git show gh-pages:DailyBriefing/appcast.xml > dist/existing-appcast.xml 2>/dev/null; then
+              # Extract existing items from new location
+              EXISTING_ITEMS=$(sed -n '/<channel>/,/<\/channel>/p' dist/existing-appcast.xml | sed '1d;$d' | grep -v '^[[:space:]]*</channel>' || true)
+            elif git show gh-pages:DailyDigest/appcast.xml > dist/existing-appcast.xml 2>/dev/null; then
+              # Migrate from old location
+              EXISTING_ITEMS=$(sed -n '/<channel>/,/<\/channel>/p' dist/existing-appcast.xml | sed '1d;$d' | grep -v '^[[:space:]]*</channel>' || true)
+            fi
           fi
           
           # Create appcast.xml with new item first, then existing items
@@ -131,7 +137,7 @@ jobs:
                xmlns:dc="http://purl.org/dc/elements/1.1/">
             <channel>
               <title>${APP_NAME} Updates</title>
-              <link>https://juliusfrick.github.io/DailyDigest/appcast.xml</link>
+              <link>https://juliusfrick.github.io/DailyBriefing/appcast.xml</link>
               <description>Latest versions of ${APP_NAME}</description>
               <language>de</language>
               
@@ -187,18 +193,27 @@ jobs:
             git rm -rf . || true
           fi
           
-          # Create DailyDigest directory if it doesn't exist
-          mkdir -p DailyDigest
+          # Create DailyBriefing directory if it doesn't exist
+          mkdir -p DailyBriefing
           
           # Copy the new appcast.xml (generated in previous step)
-          cp dist/appcast.xml DailyDigest/appcast.xml
+          cp dist/appcast.xml DailyBriefing/appcast.xml
+          
+          # Remove old appcast.xml location if it exists (migration)
+          if [[ -f DailyDigest/appcast.xml ]]; then
+            rm -rf DailyDigest
+            echo "Removed old DailyDigest directory (migration complete)"
+          fi
           
           # Commit and push
-          git add DailyDigest/appcast.xml
-          if git diff --staged --quiet; then
+          git add DailyBriefing/appcast.xml
+          if [[ -d DailyDigest ]]; then
+            git rm -rf DailyDigest || true
+          fi
+          if git diff --staged --quiet && git diff --quiet; then
             echo "No changes to commit"
           else
-            git commit -m "Update appcast.xml for version ${{ steps.version.outputs.version }}"
+            git commit -m "Update appcast.xml for version ${{ steps.version.outputs.version }} (migrated from DailyDigest)" || git commit -m "Update appcast.xml for version ${{ steps.version.outputs.version }}"
             git push origin gh-pages
           fi
 

--- a/DailyBriefing/Sources/Core/Services/UpdateService.swift
+++ b/DailyBriefing/Sources/Core/Services/UpdateService.swift
@@ -12,7 +12,7 @@ final class UpdateService: NSObject, ObservableObject {
     // MARK: - Constants
 
     /// Default appcast URL used when Info.plist doesn't provide one
-    private static let defaultFeedURL = "https://juliusfrick.github.io/DailyDigest/appcast.xml"
+    private static let defaultFeedURL = "https://juliusfrick.github.io/DailyBriefing/appcast.xml"
 
     // MARK: - Published Properties
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ For automatic updates to work, you need to enable GitHub Pages:
 5. Save
 
 The appcast.xml will be available at:
-`https://juliusfrick.github.io/DailyDigest/appcast.xml`
+`https://juliusfrick.github.io/DailyBriefing/appcast.xml`
 
 Make sure this URL matches the `SPARKLE_FEED_URL` in your build scripts.
 

--- a/scripts/generate-appcast.sh
+++ b/scripts/generate-appcast.sh
@@ -44,7 +44,7 @@ cat > "${APPCAST_PATH}" <<EOF
      xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
     <title>${APP_NAME} Updates</title>
-    <link>https://juliusfrick.github.io/DailyDigest/appcast.xml</link>
+    <link>https://juliusfrick.github.io/DailyBriefing/appcast.xml</link>
     <description>Latest versions of ${APP_NAME}</description>
     <language>de</language>
     

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -21,7 +21,7 @@ ICON_ICNS="${ROOT_DIR}/assets/AppIcon.icns"
 VERSION="${VERSION:-0.1.0}"
 BUILD_NUMBER="${BUILD_NUMBER:-1}"
 
-SPARKLE_FEED_URL="${SPARKLE_FEED_URL:-https://juliusfrick.github.io/DailyDigest/appcast.xml}"
+SPARKLE_FEED_URL="${SPARKLE_FEED_URL:-https://juliusfrick.github.io/DailyBriefing/appcast.xml}"
 SPARKLE_PUBLIC_ED_KEY="${SPARKLE_PUBLIC_ED_KEY:-}"
 
 SPARKLE_PLIST_KEYS=""

--- a/scripts/run-app.sh
+++ b/scripts/run-app.sh
@@ -15,7 +15,7 @@ RESOURCES_DIR="${CONTENTS_DIR}/Resources"
 PLIST_PATH="${CONTENTS_DIR}/Info.plist"
 ICON_ICNS="${ROOT_DIR}/assets/AppIcon.icns"
 
-SPARKLE_FEED_URL="${SPARKLE_FEED_URL:-https://juliusfrick.github.io/DailyDigest/appcast.xml}"
+SPARKLE_FEED_URL="${SPARKLE_FEED_URL:-https://juliusfrick.github.io/DailyBriefing/appcast.xml}"
 SPARKLE_PUBLIC_ED_KEY="${SPARKLE_PUBLIC_ED_KEY:-}"
 
 SPARKLE_PLIST_KEYS=""


### PR DESCRIPTION
## Problem
Die App konnte keine Updates laden, weil die Appcast-URL noch auf den alten Pfad `DailyDigest` verwies, während die App jetzt `DailyBriefing` heißt.

## Lösung
- ✅ Alle URLs von `DailyDigest` zu `DailyBriefing` aktualisiert
- ✅ UpdateService verwendet jetzt die korrekte Default-URL
- ✅ Release-Workflow migriert automatisch die alte appcast.xml beim nächsten Release
- ✅ Alle Build-Skripte verwenden die neue URL

## Migration
Der Release-Workflow wurde erweitert, um:
1. Beim nächsten Release automatisch die alte Datei (`DailyDigest/appcast.xml`) zu lesen, falls vorhanden
2. Die neue Datei unter `DailyBriefing/appcast.xml` zu erstellen
3. Die alte Datei automatisch zu löschen

## Testing
Nach dem nächsten Release sollte die Update-Funktion wieder funktionieren.