### PR TITLE
feat: MeetingDetailPopup – Popup für Kalender-Events

### DIFF
--- a/DailyBriefing/Sources/Features/Recording/RecordingHUDView.swift
+++ b/DailyBriefing/Sources/Features/Recording/RecordingHUDView.swift
@@ -96,7 +96,9 @@ struct VisualEffectView: NSViewRepresentable {
     }
 }
 
-#Preview {
-    RecordingHUDView()
-        .padding()
+struct RecordingHUDView_Previews: PreviewProvider {
+    static var previews: some View {
+        RecordingHUDView()
+            .padding()
+    }
 }

--- a/DailyBriefing/Sources/UI/Styles/AppStyles.swift
+++ b/DailyBriefing/Sources/UI/Styles/AppStyles.swift
@@ -129,6 +129,21 @@ extension Color {
     static let invertedText = tuiBackground
 }
 
+// MARK: - Linear Gradient Helpers
+
+extension LinearGradient {
+    static let glassOverlay = LinearGradient(
+        colors: [Color.white.opacity(0.06), Color.clear],
+        startPoint: .top,
+        endPoint: .bottom
+    )
+    static let subtleBorder = LinearGradient(
+        colors: [Color.primary.opacity(0.15), Color.primary.opacity(0.08)],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+}
+
 // MARK: - TUI Animations
 
 extension Animation {


### PR DESCRIPTION
## Was

Neues `MeetingDetailPopup` das beim Klick auf ein Kalender-Event aufgeht.

### Features
- **Details**: Zeit, Ort, Attendees, Beschreibung alles auf einem Blick
- **Recording**: Aufnahme direkt aus dem Popup starten/stoppen (`AudioRecordingService`)
- **Transkription**: Nach der Aufnahme einknopf-transkribieren (`VoxtralTranscriptionService`, Diarization enabled)
- **Notizen**: Editbare Notizen pro Event, werden automatisch gespeichert (`MeetingNotesService`)
- **Join Meeting**: Direkter Button wenn Meeting-Link vorhanden
- **ESC zum Schließen**

### Geändert
- `TUIItemRow` — Kalender-Events (haben `timestamp` oder `meetingLink`) öffnen jetzt das Popup; andere Items bleiben wie vorher (inline-expand)
- `UpcomingMeetingRow` — öffnet Popup statt direkten Link
- `MeetingRow` (Kalender-Tab-Liste) — öffnet Popup
- `EventBlock` (Wochenkalender-Grid) — klickbar, öffnet Popup

### Neue Datei
- `MeetingDetailPopup.swift`